### PR TITLE
Handle missing or mismatched growing seasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ tool supports two ways to supply crop values and growing seasons:
 * specify a single value and growing season to apply to all sampled crop
   codes.
 
+If the *Default Growing Season* parameter is left blank, crops without a
+specified season are treated as year-round. When an event month falls
+outside a crop's listed growing season, the tool assumes year-round
+susceptibility and emits a warning.
+
 For each flood depth raster the toolbox produces a two–band raster
 containing crop type and damage fraction, a CSV summary table and
 performs a Monte Carlo analysis with user‑defined uncertainty and number


### PR DESCRIPTION
## Summary
- Treat crops with empty or mismatched growing seasons as year-round while warning users
- Clarify Default Growing Season parameter behavior in code and README

## Testing
- `python -m py_compile AgFloodDamageEstimator.pyt`


------
https://chatgpt.com/codex/tasks/task_e_68924d9f644883309d65bd82c883b2be