### PR TITLE
Add per-crop flood damage summaries and Excel output

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ susceptibility and emits a warning.
 For each flood depth raster the toolbox produces a two–band raster
 containing crop type and damage fraction, a CSV summary table and
 performs a Monte Carlo analysis with user‑defined uncertainty and number
-of simulations.  Results are annualized using the U.S. Army Corps of
-Engineers trapezoidal expected annual damage method and written to CSV
-files for full transparency.
+of simulations.  Results are calculated for each impacted crop and
+annualized using the U.S. Army Corps of Engineers trapezoidal expected
+annual damage method.  A detailed Excel workbook with per‑event damages,
+per‑crop expected annual damages and illustrative charts is created for
+full transparency.
 
 The tool is designed to handle very large rasters efficiently while
 producing outputs that can withstand economic review.


### PR DESCRIPTION
## Summary
- compute Monte Carlo damages per crop for each event
- derive trapezoidal EAD both overall and by crop
- export detailed results and charts to an Excel workbook

## Testing
- `python -m py_compile AgFloodDamageEstimator.pyt`


------
https://chatgpt.com/codex/tasks/task_e_689296ab6c988330a2e0842642fa8445