### PR TITLE
Include uncertainty metrics in event damage exports

### DIFF
--- a/AgFloodDamageEstimator.pyt
+++ b/AgFloodDamageEstimator.pyt
@@ -332,9 +332,22 @@ class AgFloodDamageEstimator(object):
                     damages_runs[c].append(damaged[c])
 
             for c in crop_codes:
-                avg_damage = float(sum(damages_runs[c]) / runs)
+                arr = np.array(damages_runs[c], dtype=float)
+                avg_damage = float(arr.mean())
+                std_damage = float(arr.std(ddof=0))
+                p05 = float(np.percentile(arr, 5))
+                p95 = float(np.percentile(arr, 95))
                 name, _ = CROP_DEFINITIONS.get(c, ("Unknown", value_acre))
-                results.append({"Label": label, "RP": float(rp), "Crop": int(c), "LandCover": name, "Damage": avg_damage})
+                results.append({
+                    "Label": label,
+                    "RP": float(rp),
+                    "Crop": int(c),
+                    "LandCover": name,
+                    "Damage": avg_damage,
+                    "StdDev": std_damage,
+                    "P05": p05,
+                    "P95": p95,
+                })
 
         if not results:
             raise ValueError("No valid events provided")

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ annualized using the U.S. Army Corps of Engineers trapezoidal expected
 annual damage method. A detailed Excel workbook with per-event damages,
 per-crop expected annual damages and illustrative charts is created for
 full transparency. The exported tables include both crop codes and
-human-readable land-cover names.
+human-readable land-cover names. Per-event damage exports now also
+include the standard deviation and 5th/95th percentile damages across
+the Monte Carlo simulations to convey uncertainty.
 
 The tool is designed to handle very large rasters efficiently while
 producing outputs that can withstand economic review.


### PR DESCRIPTION
## Summary
- capture per-event uncertainty by recording standard deviation and 5th/95th percentile damages
- document uncertainty stats in README

## Testing
- `python -m py_compile AgFloodDamageEstimator.pyt`


------
https://chatgpt.com/codex/tasks/task_e_689387d348488330a48a7b9ce47f9db0