### PR TITLE
Include flooded area metrics in event exports

### DIFF
--- a/AgFloodDamageEstimator.pyt
+++ b/AgFloodDamageEstimator.pyt
@@ -314,6 +314,7 @@ class AgFloodDamageEstimator(object):
             mask = (crop_arr > 0) & (depth_arr > 0)
             crop_codes = np.unique(crop_arr[mask]).astype(int)
             damages_runs = {c: [] for c in crop_codes}
+            pixel_counts = {c: int(((crop_arr == c) & mask).sum()) for c in crop_codes}
 
             for _ in range(runs):
                 damaged = {c: 0.0 for c in crop_codes}
@@ -347,6 +348,8 @@ class AgFloodDamageEstimator(object):
                     "StdDev": std_damage,
                     "P05": p05,
                     "P95": p95,
+                    "FloodedAcres": pixel_counts[c] * cell_area_acres,
+                    "FloodedPixels": pixel_counts[c],
                 })
 
         if not results:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ per-crop expected annual damages and illustrative charts is created for
 full transparency. The exported tables include both crop codes and
 human-readable land-cover names. Per-event damage exports now also
 include the standard deviation and 5th/95th percentile damages across
-the Monte Carlo simulations to convey uncertainty.
+the Monte Carlo simulations to convey uncertainty, along with the number
+of flooded pixels and acres.
 
 The tool is designed to handle very large rasters efficiently while
 producing outputs that can withstand economic review.


### PR DESCRIPTION
## Summary
- capture flooded pixel counts per crop and compute flooded acreage
- add flooded acres and pixel counts to event damage export
- document new export fields in README

## Testing
- `python -m py_compile AgFloodDamageEstimator.pyt`


------
https://chatgpt.com/codex/tasks/task_e_689389aaf4c88330a192be4e8f30f8eb