### PR TITLE
Handle layer objects for depth raster

### DIFF
--- a/AgFloodDamageEstimator.pyt
+++ b/AgFloodDamageEstimator.pyt
@@ -267,7 +267,13 @@ class AgFloodDamageEstimator(object):
 
         for row in event_table:
             depth_path, month, rp = row
-            depth_str = depth_path.valueAsText if hasattr(depth_path, 'valueAsText') else str(depth_path)
+            depth_str = (
+                depth_path.valueAsText
+                if hasattr(depth_path, "valueAsText")
+                else depth_path.dataSource
+                if hasattr(depth_path, "dataSource")
+                else str(depth_path)
+            )
             if not depth_str:
                 continue
             depth_desc = arcpy.Describe(depth_str)


### PR DESCRIPTION
## Summary
- Improve depth raster handling in AgFloodDamageEstimator by resolving layer objects
- Prefer `valueAsText` then `dataSource` before falling back to `str(depth_path)`

## Testing
- `python -m py_compile AgFloodDamageEstimator.pyt`
- `python AgFloodDamageEstimator.pyt` *(fails: ModuleNotFoundError: No module named 'arcpy')*


------
https://chatgpt.com/codex/tasks/task_e_6893c60a303083309f8f3d42caad333d