### PR TITLE
Add crop-specific depth damage curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ specified season are treated as year-round. When an event month falls
 outside a crop's listed growing season, the tool assumes year-round
 susceptibility and emits a warning.
 
+The *Specific Crop Depth Damage Curve* parameter allows custom
+depth-damage relationships for particular crop codes. Provide the crop
+code on one line and its depth-damage curve on the following line (for
+example: `42` on one line and `0:0,1:0.5,2:1` on the next). Listed codes
+override the default *Depth-Damage Curve* while other crops continue to
+use the default relationship.
+
 For each flood depth raster the toolbox produces a two–band raster
 containing crop type and damage fraction, a CSV summary table and
 performs a Monte Carlo analysis with user-defined uncertainty and number


### PR DESCRIPTION
## Summary
- allow defining depth-damage curves for specific crop codes
- apply custom curves during damage calculations
- document specific crop depth-damage curve parameter

## Testing
- `python -m py_compile AgFloodDamageEstimator.pyt`


------
https://chatgpt.com/codex/tasks/task_e_68b88fa41c6083308feb4da1002758c1