### PR TITLE
Fix land cover filter parsing for damage points

### DIFF
--- a/AgFloodDamageEstimator.pyt
+++ b/AgFloodDamageEstimator.pyt
@@ -182,7 +182,11 @@ def _parse_crop_filter(value: Optional[str]) -> Optional[FrozenSet[int]]:
     if not value:
         return None
 
-    selections = []
+    selections: List[int] = []
+    name_lookup: Dict[str, List[int]] = defaultdict(list)
+    for code, (name, _) in CROP_DEFINITIONS.items():
+        name_lookup[name.strip().lower()].append(int(code))
+
     for part in str(value).split(";"):
         token = part.strip()
         if not token:
@@ -191,11 +195,25 @@ def _parse_crop_filter(value: Optional[str]) -> Optional[FrozenSet[int]]:
             token = token.split(" - ", 1)[0]
         try:
             selections.append(int(token))
+            continue
         except ValueError:
+            pass
+
+        normalized = token.lower()
+        if normalized in name_lookup:
+            selections.extend(name_lookup[normalized])
             continue
 
+        digits = "".join(ch for ch in token if ch.isdigit())
+        if digits:
+            try:
+                selections.append(int(digits))
+                continue
+            except ValueError:
+                pass
+
     if not selections:
-        return frozenset()
+        return None
 
     return frozenset(selections)
 


### PR DESCRIPTION
## Summary
- accept land cover selections by code, label text, or name when parsing the damage point filter
- skip applying the filter if no valid selections are provided so that all points are exported

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6902593cda148330813c4e17021743d5