### PR TITLE
Add spatial reference and attribute fields to damage points

### DIFF
--- a/tests/test_curve_parsing.py
+++ b/tests/test_curve_parsing.py
@@ -88,7 +88,15 @@ def _load_estimator_module():
 
     # Provide a lightweight stub for arcpy so the estimator can be imported
     # in test environments where ArcPy is unavailable.
-    sys.modules.setdefault("arcpy", types.ModuleType("arcpy"))
+    arcpy_stub = sys.modules.setdefault("arcpy", types.ModuleType("arcpy"))
+
+    if not hasattr(arcpy_stub, "SpatialReference"):
+        class _SpatialReference:
+            def __init__(self, wkid=None):
+                self.factoryCode = wkid
+                self.name = f"WKID {wkid}" if wkid is not None else None
+
+        arcpy_stub.SpatialReference = _SpatialReference
 
     module_path = Path(__file__).resolve().parents[1] / "AgFloodDamageEstimator.pyt"
     loader = importlib.machinery.SourceFileLoader(module_name, str(module_path))


### PR DESCRIPTION
## Summary
- add a dedicated NAD 1983 BLM Zone 10N spatial reference for the optional damage point feature class
- populate new Name and FoundHT attributes for each exported point, including per-land-cover numbering and coordinate reprojection
- extend the unit test ArcPy stub so the toolbox can still be imported when SpatialReference is referenced at module import time

## Testing
- pytest tests/test_curve_parsing.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b68696a9083309fdb001a2639bd75)